### PR TITLE
Use friendlier codepoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ This is an example of a pretty JSON stream with three objects:
 
 ### The server
 
-Running `ugly_json_server.py` will start an HTTP server on port 8001, serving an infinite stream of random data via the "ugly JSON stream" protocol.
+Running `ugly_json_server.py` will start an HTTP server on port 8001, serving an infinite stream of random data via the "ugly JSON stream" protocol. Once it's running, you can look at its output using a command-line HTTP tool such as `curl`:
 
-`ugly_json_server.py` will give you fairly messy data, ensuring that your code can handle all the cases that can come up in JSON. One important consequence of this is that you won't be able to run the server if your Python doesn't have full support for Unicode. Some versions of Python 2 for Windows, as well as the version that comes pre-installed on Mac OS, limit their Unicode support to the Basic Multilingual Plane. This is called a "narrow build" of Python.
+    curl -s localhost:8001
 
-While the server will run on recent versions of Python 2 or 3, it won't run on a narrow build. If your `sys.maxunicode` is 65535 instead of 1114111, you'll get an error suggesting that you should use Python 3.
+`ugly_json_server.py` will give you fairly messy data, ensuring that your code can handle all the cases that can come up in JSON.
+
 
 
 ### Command-line options

--- a/ugly_json_server.py
+++ b/ugly_json_server.py
@@ -79,7 +79,7 @@ def make_random_scalar():
             'yes', 'no', 'maybe', ':)', '',
             '[{"This looks like JSON": "but it\'s actually a string"}]',
             "'", '"', "hello, world", '{', '}', '[',
-            ']', "back\\slash", "\\\"\\\\", "\x00", "漢字", -1, 0, 1, 2, 3, 5,
+            ']', "back\\slash", "\\\"\\\\", "漢字", -1, 0, 1, 2, 3, 5,
             8, 0.0, 10000, 6.283185, 6.02e23, 1e-30, True, False, None
         ])
 

--- a/ugly_json_server.py
+++ b/ugly_json_server.py
@@ -62,9 +62,9 @@ def make_random_characters():
     """
     def random_char():
         if random.random() < 0.9:
-            return chr(random.randrange(0x20, 0x7f))
+            return unichr(random.randrange(0x20, 0x7f))
         else:
-            return chr(random.choice(SAFE_CODEPOINTS))
+            return unichr(random.choice(SAFE_CODEPOINTS))
     return ''.join(random_char() for i in range(random.randint(1, 4)))
 
 


### PR DESCRIPTION
Build the Unicode literals out of "safe" codepoints that should not mess up Python 2 or your terminal. This should remove one hurdle in the way of the task.